### PR TITLE
Update flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
     in {
         packages.${system}.default = pkgs.stdenv.mkDerivation {
             pname = "meowdo";
-            version = "1.0";
+            version = "1.1";
             src = self;
 
             nativeBuildInputs = [ pkgs.gcc pkgs.gnumake ];


### PR DESCRIPTION
Due to the addition of the adherence to XDG standards, up the version to 1.1 so that updates can flow properly. Tested, builds properly and works, all todos now go in `~/.local/share/meowdo/todos.txt` with the new built version.