### PR TITLE
A small flurry of changes, with one major notable addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ cd Meowdo
 make
 ```
 
+This will compile the program using the provided `Makefile`.  
+**Do not run as root** – the program writes to `~/.local/share/meowdo/`.
+
+#### Nix/NixOS
+
+There are two methods to build Meowdo using Nix: the flake and the package.
+
+Note that the package (`default.nix`) will always do the latest tagged release, which as of writing is `1.0.0`. The flake is for the latest development commit (or "unstable") version.
+
 If using the Nix flake, you will first need to [install Nix](https://nixos.org/download/) and enable Nix flakes.
 
 If not on NixOS, add this to `~/.config/nix/nix.conf`:
@@ -65,8 +74,17 @@ nix.settings.experimental-features = [
 
 And rebuild, then run `nix build .` in the project folder.
 
-This will compile the program using the provided `Makefile`.  
-**Do not run as root** – the program writes to `~/.local/share/meowdo/`.
+Of using the package (`default.nix`), do this command:
+
+```nix
+nix-build -E 'with import <nixpkgs> { }; callPackage ./default.nix {}'
+```
+
+This will then build the package.
+
+Both methods create `./result/bin/meowdo`, which can be run.
+
+Note that getting this into the [nixpkgs](https://github.com/NixOS/nixpkgs/) repo is in the works by [Dusk](https://github.com/XDuskAshes/), aka the person writing this nix section.
 
 ## Usage
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation rec {
+    pname = "meowdo";
+    version = "1.0.0";
+
+    src = fetchFromGitHub {
+        owner = "Sycorlax";
+        repo = "Meowdo";
+        rev = "v${version}";
+        sha256 = "sha256-xOdaK53KEAwjlzdYsagoZYetNRpK64+HfzvioI+PPA8=";
+    };
+
+    buildInputs = [ ncurses ];
+
+    buildPhase = '' # The Makefile is a little weird, with the main task as 'meowdo'.
+        runHook preBuild
+        make meowdo
+        runHook postBuild
+    '';
+
+    installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/bin
+        cp meowdo $out/bin/
+
+        runHook postInstall
+    '';
+
+    meta = with lib; {
+        description = "meowdo deriv test";
+    };
+}

--- a/default.nix
+++ b/default.nix
@@ -29,6 +29,11 @@ stdenv.mkDerivation rec {
     '';
 
     meta = with lib; {
-        description = "meowdo deriv test";
+        description = "a cute, keyboard-driven todo list with a cat sidekick.";
+        longDescription = ''
+            meowdo is a cute, keyboard-driven todo list with a cat sidekick. It lives inyour terminal, supports tags, search, pinning, and remembers everything in ~/.local/share/meowdo/todos.txt 
+        ''
+        homepage = https://github.com/Sycorlax/Meowdo/;
+        license = licenses.gpl3;
     };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
     in {
         packages.${system}.default = pkgs.stdenv.mkDerivation {
             pname = "meowdo";
-            version = "1.2";
+            version = "dev-4"; # Development, revision (version line change) 4 of the flake
             src = self;
 
             nativeBuildInputs = [ pkgs.gcc pkgs.gnumake ];


### PR DESCRIPTION
As always, these are all related to the Nix stuff.

Changes:

1. Added a `default.nix` file, making a proper package file for Meowdo, and is intended to follow tagged releases such as the recent `1.0.0`. The end goal with finally making this is to contribute it directly into [nixpkgs](https://github.com/NixOS/nixpkgs/), the main repository for Nix packages. Whenever I figure out the convoluted and involved process for that.
2. Update the `flake.nix` naming convention for the version number, changing it to `dev-(flake revision)`, currently 4, to separate it from the `default.nix` that is meant to follow tagged releases as mentioned.
3. Added information to the README about building with the `default.nix` file as well as a little restructure to make sure the instructions in the README actually flow well. The 'do not run this as root' warning used to be at the bottom of the Nix packaging things, and it flows better being with the primary build instructions.
4. Update `flake.lock`, the file that pins the current `nixpkgs` version for the flake. This part is just maintenance work.