### PR TITLE
Small Nix cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Pull requests are welcome! Please ensure:
 ## Acknowledgements
 
 - [Bertieio](https://github.com/Bertieio/) – AUR packaging and maintenance
-- [Dusk](https://github.com/XDuskAshes/) – Nix flake & package support, working on nixpkgs submission
+- [Dusk](https://github.com/XDuskAshes/) – Nix flake & package support, working on nixpkgs submission (currently stalled, as contributing to nixpkgs is difficult okay 3: -Dusk)
  
 ## License
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,10 +15,14 @@
     let
         system = "x86_64-linux";
         pkgs = nixpkgs.legacyPackages.${system};
+        revision = "5"; # Change this for every time you add a new
+                        # dependency. Refer to https://search.nixos.org/packages
+                        # to find packages matching your possible future
+                        # dependencies.
     in {
         packages.${system}.default = pkgs.stdenv.mkDerivation {
             pname = "meowdo";
-            version = "dev-4"; # Development, revision (version line change) 4 of the flake
+            version = "dev-${revision}";
             src = self;
 
             nativeBuildInputs = [ pkgs.gcc pkgs.gnumake ];


### PR DESCRIPTION
Changed files:

- `flake.nix`
- `flake.lock`
- `README.md`

Changes explanation:
In `flake.nix`, in the `let ... in` statement before the package, there's a new `revision` field. Should you add new dependencies, you should change this revision number.

In `README.md` I just added that contributing to nixpkgs is difficult and involved.

`flake.lock` is just lockfile update, package builds and runs fine with latest nixpkgs unstable.