### PR TITLE
made more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,14 @@
-CC     = gcc
+CC = cc
 CFLAGS = -O2 -Wall -Wextra
+LIBS = -lncurses
 
-# Try ncursesw first (Debian/Ubuntu), fall back to ncurses (Arch/macOS)
-LIBS = $(shell pkg-config --libs ncursesw 2>/dev/null || \
-        pkg-config --libs ncurses  2>/dev/null || \
-        echo -lncurses)
-
-CFLAGS += $(shell pkg-config --cflags ncursesw 2>/dev/null || \
-           pkg-config --cflags ncurses  2>/dev/null || true)
+all: meowdo
 
 meowdo: meowdo.c
-	$(CC) $(CFLAGS) -o $@ $< $(LIBS)
+	$(CC) $(CFLAGS) -o meowdo meowdo.c $(LIBS)
 
-debug: CFLAGS += -g
-debug: meowdo
+debug:
+	$(MAKE) CFLAGS="$(CFLAGS) -g" all
 
 clean:
 	rm -f meowdo

--- a/meowdo.c
+++ b/meowdo.c
@@ -42,6 +42,15 @@
 #include <stdbool.h>
 #include <wchar.h>
 
+static void flush_input(void) {
+    int ch;
+    timeout(0);
+    while ((ch = getch()) != ERR) {
+        (void)ch;
+    }
+    timeout(-1);
+}
+
 /* ------ constants ------ */
 #define MAX_TODOS  1024
 #define MAX_LINE    256
@@ -1055,7 +1064,7 @@ int main(int argc, char *argv[]){
                 set_smsg("task added! nya~");
             }
             /* flush any queued input from popup interaction */
-            timeout(0); while(getch()!=ERR); timeout(-1);
+            flush_input();
             break;
         }
 
@@ -1069,7 +1078,7 @@ int main(int argc, char *argv[]){
                 todos_save(); rebuild_vis(); set_smsg("task updated! nya~");
             }
             /* flush any queued input from popup interaction */
-            timeout(0); while(getch()!=ERR); timeout(-1);
+            flush_input();
             break;
         }
 
@@ -1114,7 +1123,7 @@ int main(int argc, char *argv[]){
             } else {snprintf(t->tag, MAX_TAG, "none");set_smsg("tag cleared");}
             todos_save(); rebuild_vis(); mark_dirty();
             /* flush any queued input from popup interaction */
-            timeout(0); while(getch()!=ERR); timeout(-1);
+            flush_input();
             break;
         }
 
@@ -1133,7 +1142,7 @@ int main(int argc, char *argv[]){
                 set_smsg("deleted! poof~");
             }
             /* flush any queued input from popup interaction */
-            timeout(0); while(getch()!=ERR); timeout(-1);
+            flush_input();
             break;
         }
 
@@ -1148,7 +1157,7 @@ int main(int argc, char *argv[]){
                 set_smsg("clean slate! fresh start nya~");
             }
             /* flush any queued input from popup interaction */
-            timeout(0); while(getch()!=ERR); timeout(-1);
+            flush_input();
             break;
         }
 
@@ -1159,7 +1168,7 @@ int main(int argc, char *argv[]){
             else search[0]='\0';
             sel=0; list_top=0; rebuild_vis();
             /* flush any queued input from popup interaction */
-            timeout(0); while(getch()!=ERR); timeout(-1);
+            flush_input();
             break;
         }
 


### PR DESCRIPTION
Improve portability of the Makefile.
remove hardcoded gcc
use cc instead
avoid Linux-specific pkg-config dependency for ncurses
improve compatibility with FreeBSD and other Unix-like systems